### PR TITLE
ci: run UT, ST and mocked E2E on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,214 @@
+# Copyright (C) 2026-2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# UT / ST / E2E on GitHub-hosted Linux runners. The jobs only call the
+# repository entry points documented in .ci/README.md, so CI cannot drift into
+# a second, GitHub-only test definition. Every layer is hermetic: no model
+# credentials, no live endpoints, no NPU. The opt-in live layers
+# (ci:st:real, ci:e2e:real, ci:st:npu, ci:e2e:legacy) stay out of this file.
+
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ut:
+    name: UT
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+          cache: pnpm
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      # ut-runner executes real bubblewrap. Ubuntu 24.04 runners ship an
+      # AppArmor policy that denies unprivileged user namespaces, which the
+      # sandbox needs; without this the Runner tests fail on the host policy
+      # rather than on product behaviour.
+      - name: Provision the bubblewrap sandbox
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends bubblewrap
+          sudo sysctl --write kernel.apparmor_restrict_unprivileged_userns=0 || true
+          bwrap --ro-bind / / --dev /dev true
+          bwrap --version
+
+      - name: Run UT
+        env:
+          CI_RESULTS_DIR: ${{ github.workspace }}/.ci-results
+          CI_RUNTIME_DIR: ${{ runner.temp }}/ci-runtime
+        run: pnpm ci:ut
+
+      - name: Upload UT results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ut-results
+          path: .ci-results/ut
+          if-no-files-found: warn
+
+  st:
+    name: ST
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+          cache: pnpm
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      # The hermetic agent loop drives a scripted local endpoint and performs a
+      # real workspace tool round trip; no sandbox and no model credential.
+      - name: Run ST
+        env:
+          CI_RESULTS_DIR: ${{ github.workspace }}/.ci-results
+          CI_RUNTIME_DIR: ${{ runner.temp }}/ci-runtime
+        run: pnpm ci:st
+
+      - name: Upload ST results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: st-results
+          path: .ci-results/st
+          if-no-files-found: warn
+
+  e2e:
+    name: E2E (mocked)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+          cache: pnpm
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      # Mocked journeys start the product stack, whose Runner executes
+      # bubblewrap, and Chromium's own sandbox needs the same capability.
+      - name: Provision the bubblewrap sandbox
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends bubblewrap
+          sudo sysctl --write kernel.apparmor_restrict_unprivileged_userns=0 || true
+          bwrap --ro-bind / / --dev /dev true
+          bwrap --version
+
+      # Keyed on the committed E2E lockfile, which pins the only Playwright
+      # version .ci/run-e2e.sh is allowed to install.
+      - name: Cache the pinned Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('test/e2e.package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-
+
+      # run-e2e.sh owns the whole lifecycle: it syncs .e2e, installs Chromium,
+      # generates an ephemeral token, starts and stops its own isolated stack,
+      # runs the @mocked project and collects reports. E2E_COMMIT_SHA stamps
+      # journey reports with the revision under test.
+      - name: Run mocked E2E
+        env:
+          CI_RESULTS_DIR: ${{ github.workspace }}/.ci-results
+          CI_RUNTIME_DIR: ${{ runner.temp }}/ci-e2e
+          E2E_COMMIT_SHA: ${{ github.sha }}
+        run: pnpm ci:e2e
+
+      # Playwright exits 0 on skips, so a BLOCKED journey — J3 whenever the
+      # default run keeps SCIENTIFIC_ENVS=0 — would otherwise vanish behind a
+      # green check. The repository rule is that blocked is not passed, so the
+      # counts and every not-passed title go into the run summary.
+      - name: Summarize the E2E outcome
+        if: always()
+        run: |
+          results=.ci-results/e2e/test-results/results.json
+          if [[ ! -f "$results" ]]; then
+            echo "### E2E (mocked)" >> "$GITHUB_STEP_SUMMARY"
+            echo "No Playwright results.json; the layer stopped before test execution." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node -e '
+            const fs = require("node:fs");
+            const report = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const stats = report.stats;
+            const notPassed = [];
+            const walk = (suite) => {
+              for (const spec of suite.specs ?? []) {
+                const status = spec.tests?.[0]?.results?.[0]?.status ?? "unknown";
+                if (!spec.ok || status === "skipped") notPassed.push(`${status} — ${spec.title}`);
+              }
+              for (const child of suite.suites ?? []) walk(child);
+            };
+            for (const suite of report.suites ?? []) walk(suite);
+            const lines = [
+              "### E2E (mocked)",
+              "",
+              `passed **${stats.expected}** · skipped/blocked **${stats.skipped}** · failed **${stats.unexpected}** · flaky **${stats.flaky}**`,
+            ];
+            if (notPassed.length > 0) {
+              lines.push("", "Not passed (a skip may be a BLOCKED precondition, not a success):", "");
+              for (const entry of notPassed) lines.push(`- ${entry}`);
+            }
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
+          ' "$results"
+
+      # Failure evidence — Playwright report, traces, screenshots, journey
+      # reports, and the stack log that attributes a stack-side failure.
+      - name: Upload E2E results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results
+          path: .ci-results/e2e
+          if-no-files-found: warn
+          retention-days: 14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@sciencediscovery/schema':
         specifier: workspace:*
         version: link:../../packages/schema
+      cytoscape:
+        specifier: ^3.34.0
+        version: 3.34.1
+      cytoscape-dagre:
+        specifier: ^4.0.0
+        version: 4.0.0(cytoscape@3.34.1)
       d3-drag:
         specifier: ^3.0.0
         version: 3.0.0
@@ -75,6 +81,9 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
     devDependencies:
+      '@types/cytoscape':
+        specifier: ^3.31.0
+        version: 3.31.0
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
@@ -838,6 +847,10 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cytoscape@3.31.0':
+    resolution: {integrity: sha512-EXHOHxqQjGxLDEh5cP4te6J0bi7LbCzmZkzsR6f703igUac8UGMdEohMyU3GHAayCTZrLQOMnaE/lqB2Ekh8Ww==}
+    deprecated: This is a stub types definition. cytoscape provides its own type definitions, so you do not need this installed.
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -1239,6 +1252,15 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-dagre@4.0.0:
+    resolution: {integrity: sha512-wsDgi1hHpWfslQxe/Gd/xCCeg2YUDrzwulhHOSI7fMfll92FFVY2AWhSRulLiOVcyDE4zz0rRd/+1TBTw+ew5Q==}
+    peerDependencies:
+      cytoscape: ^3.2.22
+
+  cytoscape@3.34.1:
+    resolution: {integrity: sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==}
+    engines: {node: '>=0.10'}
 
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
@@ -2408,6 +2430,10 @@ snapshots:
     dependencies:
       '@types/node': 26.1.1
 
+  '@types/cytoscape@3.31.0':
+    dependencies:
+      cytoscape: 3.34.1
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -2770,6 +2796,12 @@ snapshots:
       which: 2.0.2
 
   csstype@3.2.3: {}
+
+  cytoscape-dagre@4.0.0(cytoscape@3.34.1):
+    dependencies:
+      cytoscape: 3.34.1
+
+  cytoscape@3.34.1: {}
 
   d3-color@3.1.0: {}
 


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs the three existing test layers, and fixes a lockfile mismatch that currently makes all three of them fail before any test executes.

## `.github/workflows/ci.yml`

Three parallel jobs calling only the entry points already documented in `.ci/README.md`, so CI cannot drift into a second, GitHub-only test definition:

| Job | Command |
|---|---|
| UT | `pnpm ci:ut` |
| ST | `pnpm ci:st` |
| E2E (mocked) | `pnpm ci:e2e` |

Triggers on push to `main`/`master`, on pull requests, and manually. Only the hermetic layers are wired up — `ci:st:real`, `ci:e2e:real`, `ci:st:npu` and `ci:e2e:legacy` need credentials or hardware and stay behind their `CI_ALLOW_*` gates.

Three differences between a hosted runner and the `.ci` image had to be handled explicitly:

- **Result and runtime directories.** `run-layer.mjs` and `run-e2e.sh` default to `/ci-results` and `/ci-cache`, which exist only inside the `.ci` image. The jobs point `CI_RESULTS_DIR` into the workspace and `CI_RUNTIME_DIR` into the runner temp directory — deliberately outside the checkout, so the Runner sandbox never mounts over the data directory.
- **Sandbox capability.** `ut-runner` and the mocked journeys execute bubblewrap, and Chromium needs the same unprivileged user namespaces, which the Ubuntu 24.04 runner image denies by AppArmor policy. The jobs install bubblewrap, clear `kernel.apparmor_restrict_unprivileged_userns`, and run a `bwrap` preflight so a host policy problem fails as infrastructure instead of masquerading as a product failure.
- **Chromium cache**, keyed on `test/e2e.package-lock.json` — the file that pins the only Playwright version `run-e2e.sh` is allowed to install.

Every job uploads its `.ci-results/<layer>` directory on `always()`. For E2E that includes the Playwright report, `test-results` (traces and failure screenshots), the journey reports, and `stack.log` for attributing a stack-side failure.

One extra step, `Summarize the E2E outcome`, parses `test-results/results.json` and writes the passed/skipped/failed/flaky counts plus every not-passed title into the run summary. Playwright exits 0 on skips, so without it a run where J3 reports BLOCKED (`SCIENTIFIC_ENVS=0`) and the connector case skips looks indistinguishable from one where all seven journeys ran. It reports only and does not change the pass/fail verdict — turning a documented BLOCKED precondition into a red build is a policy decision, not something this PR should decide.

## Lockfile fix

`apps/web/package.json` declares `cytoscape`, `cytoscape-dagre` and `@types/cytoscape`, but `pnpm-lock.yaml` has no entry for any of them. Every `pnpm install --frozen-lockfile` therefore aborts with `ERR_PNPM_OUTDATED_LOCKFILE` — and that is the first command in all three layer entry points, and the default whenever `CI=1`:

```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/apps/web/package.json
* 3 dependencies were added: @types/cytoscape@^3.31.0, cytoscape@^3.34.0, cytoscape-dagre@^4.0.0
```

It reproduces locally with `CI=1 pnpm install --frozen-lockfile`; local development does not hit it because `node_modules` is already populated. Regenerated with `pnpm install --lockfile-only`; the diff is additive (+32 lines) and changes no existing resolution. Kept as a separate commit so it can be taken independently of the workflow.

Side note for whoever owns that dependency: `@types/cytoscape` is a deprecated stub — cytoscape ships its own type definitions.

## Validation

Executed on a fork before opening this PR, most recently on the rebased commit:

- UT — 1m46s; 382 api tests pass, memory-graph pytest 44 passed / 27 skipped
- ST — 36s; hermetic `run_m1_smoke.sh` round trip
- E2E (mocked) — 1m44s; 7 discovered, 5 passed, 2 skipped in 27.3s

The two skips are the documented ones: J3 (BLOCKED, no managed environments in the default run) and the connector case in `literature-review.spec.ts`.

One observation while reading the results: `.ci/README.md` states the mocked suite has a known J4 failure, where only the main artifact appears in the Project catalog. On this revision J4 passes and its journey report is PASS, so that paragraph looks stale and could be dropped or re-scoped.
